### PR TITLE
Implement MixAttention as described by DataBricks

### DIFF
--- a/configs/local_test_synthetic.yaml
+++ b/configs/local_test_synthetic.yaml
@@ -23,6 +23,12 @@ model:
   vocab: 32768 
   d_ff: 1024
   rope_max_timescale: 256
+
+  # parameters for mixattention
+  window_size: 128
+  ma_pair: true
+  block_starts: (0, 12)
+
   a_attn: 1
   a_output: 1
   zero_queries: true

--- a/train.py
+++ b/train.py
@@ -355,9 +355,7 @@ class Model:
         # Transformer blocks.
         @explicit_activation_checkpointing
         @typechecked
-        def loop_body(
-            carry: Tuple[bf16[b"B/d L M/t"], int], layer_weights: Any
-        ) -> Tuple[Tuple[bf16[b"B/d L M/t"], int], Tuple[()]]:
+        def loop_body(carry: Any, layer_weights: Any) -> Tuple[Any, Tuple[()]]:
 
             x, layer_idx = carry
             if layer_idx in h.block_starts:


### PR DESCRIPTION
Implement MixAttention as described [here](https://www.databricks.com/blog/mixattention)

- To use MA Pairs, add flag
- For other MA forms, you can specify in block starts
  - For MA: `block_starts: (0)`, which is the KV cache of the first layer. All the other standard attention layers share this KV cache.