### PR TITLE
Implement Multi-Head Latent Attention

### DIFF
--- a/configs/local_test_synthetic.yaml
+++ b/configs/local_test_synthetic.yaml
@@ -14,6 +14,7 @@ training:
     len: 64
   use_grad_clip: true
   use_gpu: false
+  use_single_pod: false
 
 model:
   d_model: 256

--- a/train.py
+++ b/train.py
@@ -270,7 +270,7 @@ class Model:
         d_model_scale = (
             math.sqrt(base.d_model) / (h.d_model * truncated_normal_stddev)
         ) ** (p.hidden_init_var)
-        w_kv_scale = d_model_scale
+
         target_head_dim = h.n_h * h.d_head
         base_head_dim = base.n_h * base.d_head
         w_o_scale = (
@@ -279,11 +279,6 @@ class Model:
         w_up_scale = d_model_scale
         w_down_scale = (math.sqrt(base.d_ff) / (h.d_ff * truncated_normal_stddev)) ** (
             p.hidden_init_var
-        )
-
-        w_kv_shape = (h.layers, 2, h.d_model, h.n_h, h.d_head)
-        w_kv = w_kv_scale * jax.random.truncated_normal(
-            fold_in_str(rng, "w_kv"), -2, 2, w_kv_shape, dtype=jnp.float32
         )
 
         ff_shape = (h.layers, h.d_model, h.d_ff)
@@ -345,6 +340,10 @@ class Model:
             h.d_model,
             h.d_compressed,
         )
+        w_kv_scale = d_model_scale
+        d_compressed_scale = math.sqrt(base.d_compressed) / (
+            h.d_compressed * truncated_normal_stddev
+        ) ** (p.hidden_init_var)
         w_k_nope_shape = (
             h.layers,
             h.d_compressed,
@@ -362,7 +361,7 @@ class Model:
             w_k_compressed_shape,
             dtype=jnp.float32,
         )
-        w_k_nope = w_kv_scale * jax.random.truncated_normal(
+        w_k_nope = d_compressed_scale * jax.random.truncated_normal(
             fold_in_str(rng, "w_k_nope"), -2, 2, w_k_nope_shape, dtype=jnp.float32
         )
         w_v = w_kv_scale * jax.random.truncated_normal(

--- a/train.py
+++ b/train.py
@@ -847,7 +847,8 @@ def training_step(
             w_q_nope=h.gamma_hidden * (h.d_model / base.d_model) ** -p.hidden_lr,
             w_k_pe=h.gamma_hidden * (h.d_model / base.d_model) ** -p.hidden_lr,
             w_k_compressed=h.gamma_hidden * (h.d_model / base.d_model) ** -p.hidden_lr,
-            w_k_nope=h.gamma_hidden * (h.d_model / base.d_model) ** -p.hidden_lr,
+            w_k_nope=h.gamma_hidden
+            * (h.d_compressed / base.d_compressed) ** -p.hidden_lr,
             w_v=h.gamma_hidden * (h.d_model / base.d_model) ** -p.hidden_lr,
             w_o=h.gamma_hidden * (target_head_dim / base_head_dim) ** -p.hidden_lr,
             w_gate=h.gamma_hidden * (h.d_model / base.d_model) ** -p.hidden_lr,


### PR DESCRIPTION
Implement the naive path for MLA implementation described here in [DeepSeek3](https://github.com/deepseek-ai/DeepSeek-V3/blob/main/inference/model.py#L230C1-L269C17):

### Changes
- Split `w_k` into `w_k_pe` and `w_k_nope`
   - we define `k_pe = nx @ w_k_rope` and `k_nope = k_compressed @ w_nope`
   - k_compressed is a LoRA representation of k
 - v gets its own projection `w_v` as part of this split
- remove GQA and move to setup more akin to MHA/MQA for MLA